### PR TITLE
Command `start_record` transport from Elixir to Rust

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,1 @@
+Mix.Task.run("compile.cargo")

--- a/lib/rpi_video.ex
+++ b/lib/rpi_video.ex
@@ -1,5 +1,8 @@
 defmodule RpiVideo do
   def start(mock \\ false), do: impl_mod(mock).start
+  def stop(mock \\ false), do: impl_mod(mock).stop
+
+  def record(mock \\ false), do: impl_mod(mock).record
 
   defp impl_mod(false), do: RpiVideo.RealServer
   defp impl_mod(true), do: RpiVideo.MockServer

--- a/lib/rpi_video/mock_server.ex
+++ b/lib/rpi_video/mock_server.ex
@@ -2,11 +2,17 @@ defmodule RpiVideo.MockServer do
   use GenServer
 
   def start do
-    GenServer.start_link(__MODULE__, %{})
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
   def stop do
     GenServer.stop(__MODULE__)
+  end
+
+  def record do
+    __MODULE__
+    |> GenServer.whereis()
+    |> start_record_on()
   end
 
   @impl true
@@ -15,7 +21,6 @@ defmodule RpiVideo.MockServer do
 
     port =
       Port.open({:spawn_executable, executable}, [
-        {:packet, 2},
         :binary,
         :exit_status,
         :use_stdio
@@ -27,19 +32,31 @@ defmodule RpiVideo.MockServer do
   end
 
   @impl true
-  def handle_info({_port, {:start, <<data::binary>>}}, state) do
-    file_path = :erlang.binary_to_term(data)
+  def handle_cast({:start_record, nil}, %{port: port} = state) do
+    data = :erlang.term_to_binary("start_record")
+    len = byte_size(data)
 
-    IO.puts("elixir_MOCK_server: Starts to record video - #{file_path}")
+    buf = [<<len::big-unsigned-integer-size(64)>>, data]
+    Port.command(port, buf)
+
+    IO.puts(:stderr, "elixir_MOCK_server: Starts to record a new video")
 
     {:noreply, state}
   end
 
   @impl true
-  def handle_info({_port, {:end, <<data::binary>>}}, state) do
+  def handle_info({_port, {:record_started, <<data::binary>>}}, state) do
     file_path = :erlang.binary_to_term(data)
 
-    IO.puts("elixir_MOCK_server: Finishes recording video - #{file_path}")
+    IO.puts(:stderr, "elixir_MOCK_server: Continues recording the video - `#{file_path}`")
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({_port, {:record_ended, <<data::binary>>}}, state) do
+    file_path = :erlang.binary_to_term(data)
+
+    IO.puts(:stderr, "elixir_MOCK_server: Finishes recording the video - `#{file_path}`")
 
     {:noreply, state}
   end
@@ -48,4 +65,9 @@ defmodule RpiVideo.MockServer do
   def handle_info({_, {:exit_status, status}}, state) do
     {:stop, {:exit, status}, state}
   end
+
+  defp start_record_on(pid) when is_pid(pid),
+  do: GenServer.cast(pid, {:start_record, nil})
+  defp start_record_on(nil),
+  do: raise("#{__MODULE__} has not been started")
 end

--- a/src/capture/capture_main_loop.rs
+++ b/src/capture/capture_main_loop.rs
@@ -1,14 +1,18 @@
+extern crate eetf;
 extern crate libc;
 extern crate nix;
 
-use std::os::unix::io::RawFd;
+use std::io::{Cursor, Read, Stdin, stdin};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::str;
 
-use self::nix::Error;
-use self::nix::errno::{Errno, errno};
-use self::nix::fcntl;
+use self::eetf::Term;
+
+use self::nix::errno::Errno;
 use self::nix::sys::select::{FdSet, select};
 use self::nix::sys::time::{TimeVal, TimeValLike};
 use self::nix::unistd::{close, pipe, read};
+use self::nix::{Error, fcntl};
 
 use crate::capture::capture_param::CaptureParam;
 use crate::capture::capture_state::CaptureState;
@@ -29,13 +33,18 @@ impl CaptureMainLoop {
     }
 
     pub fn run(&mut self) {
-        self.init_pipe().unwrap();
+        // Initializes a `stdin` handle. It is used to receive commands from Elixir.
+        let mut stdin_handle = stdin();
+        let stdin_fd = stdin_handle.as_raw_fd();
 
+        // Initializes a `pipe`. It is used to activate main loop from `capture_tasks`.
+        self.init_pipe().unwrap();
         let pipe_read_fd = self.pipe_read_fd();
         let pipe_write_fd = self.pipe_write_fd();
 
         loop {
             let mut read_fds = FdSet::new();
+            read_fds.insert(stdin_fd);
             read_fds.insert(pipe_read_fd);
 
             // Monitors the `close` flag (0 byte).
@@ -50,7 +59,7 @@ impl CaptureMainLoop {
                     continue;
                 }
 
-                println!("Returns an unexpected error from `select` - {}", errno.desc());
+                eprintln!("\nReturns an unexpected error from `select` - {}\n", errno.desc());
                 break;
             }
 
@@ -63,15 +72,18 @@ impl CaptureMainLoop {
                 break;
             }
 
-            if !read_fds.contains(pipe_read_fd) {
-                continue;
+            if read_fds.contains(stdin_fd) {
+              self.handle_port_commands(&mut stdin_handle);
             }
 
-            self.handle_record_complete();
+            if read_fds.contains(pipe_read_fd) {
+              self.handle_record_complete();
 
-            // Flushes the pipe.
-            let mut buf = [0u8; 1];
-            read(pipe_read_fd, &mut buf).unwrap();
+              // Flushes the pipe.
+              let mut buf = [0u8; 1];
+              read(pipe_read_fd, &mut buf).unwrap();
+            }
+
         }
     }
 
@@ -85,6 +97,34 @@ impl CaptureMainLoop {
             close(pipe_write_fd).unwrap();
 
             self.pipe_fds = None;
+        }
+    }
+
+    fn dispatch_command(&self, command: &str) {
+        match command.as_ref() {
+            "start_record" => self.run_command_start_record(),
+            _ => eprintln!("\nUnsupported command `{}`\n", command),
+        }
+    }
+
+    fn handle_port_commands(&self, stdin: &mut Stdin) {
+        let mut handle = stdin.lock();
+
+        let mut len_buf = [0; 8];
+        handle.read_exact(&mut len_buf).unwrap();
+
+
+        let len = u64::from_be_bytes(len_buf);
+        let mut term_buf = Vec::new();
+        term_buf.resize(len as usize, 0);
+        handle.read_exact(&mut term_buf).unwrap();
+
+        let term = Term::decode(Cursor::new(&term_buf)).unwrap();
+        if let Term::Binary(binary) = term {
+            let command = str::from_utf8(&binary.bytes).unwrap();
+            eprintln!("\nReceives command `{}`\n", command);
+
+            self.dispatch_command(&command);
         }
     }
 
@@ -121,6 +161,12 @@ impl CaptureMainLoop {
         }
 
         panic!("`pipe_fds` has not been initialized")
+    }
+
+    fn run_command_start_record(&self) {
+
+      // TODO
+
     }
 }
 


### PR DESCRIPTION
### Summary

Transports command `start_record` from Elixir to Rust.

### TODO

Implements `start_record` on Rust part.