### PR TITLE
Update `bors.toml`

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,4 @@
 status = ["build (ubuntu-latest, 22.x, 1.9.x)"]
 
-timeout_sec = 600
+timeout_sec = 1800
+delete_merged_branches = true


### PR DESCRIPTION
### Summary

1. Increases `timeout_sec` from 10-mins to 30mins.

2. Adds `delete_merged_branches`.